### PR TITLE
feat(produto): implementa core logic para criação de produtos

### DIFF
--- a/docs/arquitetura/arquitetura.md
+++ b/docs/arquitetura/arquitetura.md
@@ -1,15 +1,46 @@
 # 🏗️ Arquitetura do Sistema
 
-O sistema segue o padrão **Ports & Adapters (Hexagonal Architecture)**, 
-separando regras de negócio da infraestrutura.
+O sistema segue o padrão **Ports & Adapters (Hexagonal Architecture)**, separando as regras de negócio da infraestrutura.
 
-## Camadas
-- **Core (Domínio):** Entidades, Value Objects, Casos de Uso e Ports.
-- **Infrastructure (Adapters):** Banco de dados, autenticação, APIs externas, web.
-- **Config:** Injeção de dependência e carregador de módulos.
+## Estrutura de Diretórios
 
-## Fluxo Geral
-Entrada (Controller) ➝ Caso de Uso ➝ Port ➝ Adapter ➝ Banco/Serviço
+Para implementar a Arquitetura Hexagonal, adotamos a seguinte estrutura de diretórios dentro de `src/`:
+
+```
+src/
+├── core/
+│   ├── entities/
+│   ├── repositories/
+│   └── use-cases/
+│
+├── infra/
+│   ├── http/
+│   │   ├── controllers/
+│   │   └── routes/
+│   ├── db/
+│   │   └── repositories/
+│   └── middlewares/
+│
+└── main.ts
+```
+
+### Responsabilidades
+
+*   `src/core` - **O Coração (Domínio):**
+    *   `entities/`: As entidades de negócio puras (ex: `Produto.ts`). Não sabem nada sobre o mundo exterior.
+    *   `repositories/`: As "Portas" de saída. São **interfaces** que definem como o `core` se comunica com a persistência de dados (ex: `IProdutoRepository.ts`).
+    *   `use-cases/`: A lógica de negócio da aplicação (ex: `CriarProduto.ts`). Orquestram as regras de negócio.
+
+*   `src/infra` - **Os Adaptadores:**
+    *   `http/`: O adaptador para o protocolo HTTP.
+        *   `controllers/`: Recebem as requisições, chamam os `use-cases` e retornam as respostas.
+        *   `routes/`: Mapeiam as rotas da API para os controllers.
+    *   `db/`: O adaptador para o banco de dados.
+        *   `repositories/`: A **implementação** concreta das interfaces de repositório (ex: `ProdutoRepositoryJson.ts`).
+    *   `middlewares/`: Funções que interceptam as requisições, como para autenticação, logs, etc.
+
+*   `src/main.ts` - **O Ponto de Partida:**
+    *   Responsável por inicializar a aplicação, configurar o servidor e conectar as peças (injeção de dependência).
 
 ---
 

--- a/docs/blog/post/002-definindo-a-arquitetura.md
+++ b/docs/blog/post/002-definindo-a-arquitetura.md
@@ -1,0 +1,45 @@
+# Diário de Bordo #2: Desenhando o Esqueleto do Projeto
+
+Com o ambiente configurado, o próximo passo era decidir como organizar nosso código. Onde cada arquivo vai? Como garantir que o projeto não vire uma bagunça daqui a alguns meses? A resposta está na **arquitetura do diretório**.
+
+## A Encruzilhada: Camadas vs. Módulos
+
+Seguindo o plano de usar a Arquitetura Hexagonal, a primeira ideia foi agrupar nosso código por **camadas técnicas**:
+
+- Uma pasta para todos os `controllers`.
+- Uma pasta para todos os `repositories`.
+- Uma pasta para todos os `use-cases`.
+
+Essa abordagem é um clássico e funciona bem. No entanto, durante a discussão, surgiu uma ideia interessante: e se agrupássemos por **módulo de negócio**?
+
+- Uma pasta `products` com tudo dentro (seu controller, seu repositório, etc.).
+- Uma pasta `sales` com tudo de vendas.
+
+Essa segunda abordagem (chamada de "Modular Monolith" ou "Feature-Sliced") é extremamente poderosa para projetos grandes, pois deixa tudo relacionado a uma funcionalidade bem isolado e coeso. É como ter mini-projetos dentro do projeto principal.
+
+## A Decisão: Simplicidade Hoje, Flexibilidade Amanhã
+
+Apesar da abordagem modular ser muito atraente (e algo que certamente quero explorar no futuro), decidimos por começar com a estrutura de **camadas**. 
+
+**Por quê?**
+
+1.  **Simplicidade para o MVP:** Para o nosso Produto Mínimo Viável, a estrutura de camadas é mais direta e nos permite construir as primeiras funcionalidades de forma mais rápida.
+2.  **Base de Aprendizado:** Implementar um padrão clássico do começo ao fim é um ótimo exercício. Entender bem a estrutura por camadas vai tornar a transição para uma estrutura modular no futuro muito mais clara.
+3.  **Refatoração como Ferramenta:** A migração de uma arquitetura de camadas para uma modular é um excelente desafio técnico e uma oportunidade de aprendizado valiosa para quando o projeto crescer.
+
+## O Esqueleto Final
+
+Então, nosso `src` ficou assim:
+
+```
+src/
+├── core/         # A lógica de negócio pura
+├── infra/        # A comunicação com o mundo exterior (HTTP, DB)
+└── main.ts       # O ponto de entrada que conecta tudo
+```
+
+Dentro de `core` e `infra`, os arquivos serão organizados por seu papel técnico (`entities`, `controllers`, etc.).
+
+Com o esqueleto definido e documentado, agora sim estamos prontos para colocar a primeira peça de carne nesse osso: a entidade `Produto`.
+
+Até a próxima!

--- a/src/core/entities/Produto.ts
+++ b/src/core/entities/Produto.ts
@@ -1,0 +1,38 @@
+import crypto from 'crypto';
+
+// A classe Produto é uma entidade central do nosso sistema.
+// Ela representa o objeto de negócio "Produto" com suas regras e propriedades.
+// Usar uma classe nos permite não só ter um formato de dados, mas também
+// adicionar métodos que contenham regras de negócio específicas do produto no futuro.
+export class Produto {
+  // Propriedades da nossa entidade
+  id: string;
+  nome: string;
+  descricao: string;
+  preco: number;
+  estoque: number;
+  criadoEm: Date;
+  atualizadoEm: Date;
+
+  // O construtor é usado para criar uma nova instância de Produto.
+  // Usamos `Partial<Produto>` para permitir a criação de um produto passando apenas algumas
+  // propriedades, enquanto outras podem ser geradas automaticamente (como id, criadoEm).
+  constructor(props: Partial<Produto>) {
+    // O `Object.assign` copia as propriedades do objeto `props` para a instância `this`.
+    Object.assign(this, props);
+
+    // Se um ID não for fornecido, um novo ID aleatório será gerado.
+    // Isso é útil para garantir que cada produto tenha um identificador único.
+    if (!props.id) {
+      this.id = crypto.randomUUID();
+    }
+
+    // Se a data de criação não for fornecida, a data atual é usada.
+    if (!props.criadoEm) {
+      this.criadoEm = new Date();
+    }
+
+    // A data de atualização é sempre definida para a data atual ao criar ou atualizar.
+    this.atualizadoEm = new Date();
+  }
+}

--- a/src/core/repositories/IProdutoRepository.ts
+++ b/src/core/repositories/IProdutoRepository.ts
@@ -1,0 +1,32 @@
+import { Produto } from '../entities/Produto';
+
+// Esta é a interface do nosso repositório de Produto (a "Porta" na Arquitetura Hexagonal).
+// Ela define um contrato, especificando quais métodos de persistência de dados
+// devem existir para a entidade Produto. A lógica de negócio (casos de uso)
+// dependerá desta abstração, e não de uma implementação concreta de banco de dados.
+export interface IProdutoRepository {
+  /**
+   * Salva um produto (cria um novo se não existir um ID, ou atualiza um existente).
+   * @param produto O objeto Produto a ser salvo.
+   */
+  save(produto: Produto): Promise<void>;
+
+  /**
+   * Busca um produto pelo seu ID.
+   * @param id O ID do produto a ser buscado.
+   * @returns O objeto Produto se encontrado, ou null caso contrário.
+   */
+  findById(id: string): Promise<Produto | null>;
+
+  /**
+   * Busca todos os produtos cadastrados.
+   * @returns Um array com todos os produtos.
+   */
+  findAll(): Promise<Produto[]>;
+
+  /**
+   * Deleta um produto pelo seu ID.
+   * @param id O ID do produto a ser deletado.
+   */
+  delete(id: string): Promise<void>;
+}

--- a/src/core/use-cases/CriarProduto.ts
+++ b/src/core/use-cases/CriarProduto.ts
@@ -1,0 +1,38 @@
+import { Produto } from '../entities/Produto';
+import { IProdutoRepository } from '../repositories/IProdutoRepository';
+
+// DTO (Data Transfer Object) para a criação de um produto.
+// Define a estrutura de dados que o caso de uso espera receber.
+export interface CriarProdutoDTO {
+  nome: string;
+  descricao: string;
+  preco: number;
+  estoque: number;
+}
+
+// Este é o nosso Caso de Uso. Ele orquestra a lógica de negócio para criar um produto.
+// Note que ele depende da ABSTRAÇÃO (IProdutoRepository) e não da implementação concreta.
+export class CriarProduto {
+  // O construtor recebe uma implementação de IProdutoRepository.
+  // Isso é chamado de Injeção de Dependência. Quem criar uma instância de `CriarProduto`
+  // terá que fornecer um repositório compatível.
+  constructor(private produtoRepository: IProdutoRepository) {}
+
+  /**
+   * O método `execute` é o ponto de entrada do caso de uso.
+   * @param data Os dados do produto a ser criado.
+   * @returns O produto que foi criado.
+   */
+  async execute(data: CriarProdutoDTO): Promise<Produto> {
+    // 1. Cria uma nova instância da entidade Produto com os dados recebidos.
+    const novoProduto = new Produto(data);
+
+    // 2. Persiste o novo produto usando o repositório.
+    // O caso de uso não sabe se está salvando em um JSON, PostgreSQL ou outro banco.
+    // Ele apenas confia no contrato definido pela interface.
+    await this.produtoRepository.save(novoProduto);
+
+    // 3. Retorna a entidade do produto recém-criado.
+    return novoProduto;
+  }
+}

--- a/src/infra/db/repositories/ProdutoRepositoryJson.ts
+++ b/src/infra/db/repositories/ProdutoRepositoryJson.ts
@@ -1,0 +1,73 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { Produto } from '../../../core/entities/Produto';
+import { IProdutoRepository } from '../../../core/repositories/IProdutoRepository';
+
+// Define a estrutura do nosso banco de dados em JSON.
+// Teremos uma chave 'produtos' que conterá um array de objetos Produto.
+interface IDatabase {
+  produtos: Produto[];
+}
+
+// Este é o nosso Adaptador de banco de dados para JSON.
+// Ele implementa a interface IProdutoRepository, traduzindo os métodos
+// da interface em operações de leitura e escrita no arquivo db.json.
+export class ProdutoRepositoryJson implements IProdutoRepository {
+  // O caminho para o nosso arquivo de banco de dados.
+  // `__dirname` é o diretório do arquivo atual, e subimos alguns níveis para chegar na raiz do projeto.
+  private readonly dbPath = path.join(__dirname, '../../../../db.json');
+
+  // Método auxiliar privado para ler o banco de dados.
+  private async readDb(): Promise<IDatabase> {
+    try {
+      const data = await fs.readFile(this.dbPath, 'utf-8');
+      // Se o arquivo estiver vazio, retorna uma estrutura de DB padrão.
+      if (!data) {
+        return { produtos: [] };
+      }
+      return JSON.parse(data) as IDatabase;
+    } catch (error) {
+      // Se o arquivo não existir, por exemplo, retorna uma estrutura de DB vazia.
+      return { produtos: [] };
+    }
+  }
+
+  // Método auxiliar privado para escrever no banco de dados.
+  private async writeDb(data: IDatabase): Promise<void> {
+    // `JSON.stringify` com `null, 2` formata o JSON de forma legível no arquivo.
+    await fs.writeFile(this.dbPath, JSON.stringify(data, null, 2));
+  }
+
+  async save(produto: Produto): Promise<void> {
+    const db = await this.readDb();
+    const index = db.produtos.findIndex((p) => p.id === produto.id);
+
+    if (index !== -1) {
+      // Se o produto já existe, atualiza.
+      db.produtos[index] = produto;
+    } else {
+      // Se não existe, adiciona ao array.
+      db.produtos.push(produto);
+    }
+
+    await this.writeDb(db);
+  }
+
+  async findById(id: string): Promise<Produto | null> {
+    const db = await this.readDb();
+    const produto = db.produtos.find((p) => p.id === id);
+    return produto || null;
+  }
+
+  async findAll(): Promise<Produto[]> {
+    const db = await this.readDb();
+    return db.produtos || [];
+  }
+
+  async delete(id: string): Promise<void> {
+    const db = await this.readDb();
+    // Filtra o array, mantendo todos os produtos cujo ID seja diferente do fornecido.
+    db.produtos = db.produtos.filter((p) => p.id !== id);
+    await this.writeDb(db);
+  }
+}


### PR DESCRIPTION
Este commit introduz a camada de lógica de negócio (core) para a entidade Produto, seguindo o padrão de Arquitetura Hexagonal.

- Cria a entidade `Produto` em `core/entities`.
- Define a porta de comunicação através da interface `IProdutoRepository`.
- Implementa o primeiro adaptador para persistência em JSON (`ProdutoRepositoryJson`).
- Adiciona o caso de uso `CriarProduto` para orquestrar a lógica de criação.
- Documenta a nova estrutura de diretórios e a decisão de arquitetura.